### PR TITLE
Questionnaire language files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use the `--input` flag to specify a custom input directory. For `export` and `wa
 
 ## Questionnaire language files
 
-Questionnaires that share the same `url` (or `id` when `url` is missing) and differ by `language` are merged into a single resource during `export` and `watch` startup.
+Questionnaires that share the same `url` (or `id` when `url` is missing) and differ by `language` are merged into a single resource during `export` and `watch` startup. On `watch`, editing any language file for a Questionnaire re-merges the group and PUTs the merged baseline resource.
 
 Rely only on `Questionnaire.language` and `Questionnaire.url` — filenames are ignored for grouping.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Rely only on `Questionnaire.language` and `Questionnaire.url` — filenames are 
 - A single questionnaire per url/id is left unchanged
 - Flat and nested `item` trees in language files are both supported (`linkId` uniqueness)
 - Only baseline `linkId`s are translated; extra `linkId`s in a variant are skipped
-- Translations are stored as FHIR primitive extensions (`_text`, `_title`, `_description`) using `http://hl7.org/fhir/StructureDefinition/translation`
+- Translations are stored as FHIR primitive extensions (`_text`, `_title`, `_description`, `_display` on `answerOption.valueCoding`) using `http://hl7.org/fhir/StructureDefinition/translation`
+- `answerOption` entries are matched by `valueCoding.code` alone; variant files may omit `system`
 
 Example layout:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ resources/
 
 Use the `--input` flag to specify a custom input directory. For `export` and `watch` commands, `--input` can be passed multiple times to load resources from several directories.
 
+## Questionnaire language files
+
+Questionnaires that share the same `url` (or `id` when `url` is missing) and differ by `language` are merged into a single resource during `export` and `watch` startup.
+
+Rely only on `Questionnaire.language` and `Questionnaire.url` — filenames are ignored for grouping.
+
+- Baseline: `language` missing or `en` (defaults to `en` when omitted)
+- Variants: other languages (`de`, `fr`, …)
+- A single questionnaire per url/id is left unchanged
+- Flat and nested `item` trees in language files are both supported (`linkId` uniqueness)
+- Only baseline `linkId`s are translated; extra `linkId`s in a variant are skipped
+- Translations are stored as FHIR primitive extensions (`_text`, `_title`, `_description`) using `http://hl7.org/fhir/StructureDefinition/translation`
+
+Example layout:
+
+```markdown
+Questionnaire/
+  demo-questionnaire.yaml      # language: en (or omitted)
+  demo-questionnaire.de.yaml   # language: de
+  demo-questionnaire.fr.yaml   # language: fr (items may be flat)
+```
+
 ## Environment variable substitution
 
 To use environment variables in resources, you can use the syntax `${VAR_NAME}`.

--- a/fhirsnake/export.py
+++ b/fhirsnake/export.py
@@ -4,6 +4,7 @@ import json
 import ndjson
 from converter import convert_resources, embed_mapping_into_resources
 from files import load_resources
+from questionnaire_language import merge_questionnaire_language_variants
 from utils import substitute_env_vars
 
 
@@ -18,6 +19,7 @@ def export_resources(
     resources_list = []
     for input_dir in input_dirs:
         resources_list.extend(flatten_resources(load_resources(input_dir)))
+    resources_list = merge_questionnaire_language_variants(resources_list)
     if embed_mapping:
         resources_list = embed_mapping_into_resources(resources_list)
     if external_questionnaire_fce_fhir_converter_url:

--- a/fhirsnake/questionnaire_language.py
+++ b/fhirsnake/questionnaire_language.py
@@ -1,0 +1,151 @@
+import copy
+import logging
+from collections import defaultdict
+
+TRANSLATION_URL = "http://hl7.org/fhir/StructureDefinition/translation"
+DEFAULT_BASELINE_LANGUAGE = "en"
+ROOT_TRANSLATABLE_FIELDS = ("title", "description")
+
+
+def merge_questionnaire_language_variants(resources_list: list[dict]) -> list[dict]:
+    """Merge Questionnaire resources that share the same url (fallback: id) but differ by language.
+
+    Non-Questionnaire resources and single-questionnaire groups pass through unchanged.
+    Multiple language variants are combined into one baseline resource with FHIR translation
+    extensions on item.text, title, and description.
+    """
+    groups: dict[str, list[dict]] = defaultdict(list)
+    non_questionnaires: list[dict] = []
+    for resource in resources_list:
+        if resource.get("resourceType") != "Questionnaire":
+            non_questionnaires.append(resource)
+            continue
+        groups[_group_key(resource)].append(resource)
+
+    result = list(non_questionnaires)
+    for key, questionnaires in groups.items():
+        if len(questionnaires) == 1:
+            result.append(questionnaires[0])
+        else:
+            result.append(_merge_group(key, questionnaires))
+    return result
+
+
+def _group_key(resource: dict) -> str:
+    return resource.get("url") or resource["id"]
+
+
+def _is_baseline_language(language: str | None) -> bool:
+    return language is None or language == DEFAULT_BASELINE_LANGUAGE
+
+
+def _merge_group(key: str, questionnaires: list[dict]) -> dict:
+    baselines = [q for q in questionnaires if _is_baseline_language(q.get("language"))]
+    if not baselines:
+        raise ValueError(
+            f"No baseline Questionnaire found for '{key}' "
+            f"(expected language missing or '{DEFAULT_BASELINE_LANGUAGE}')"
+        )
+    if len(baselines) > 1:
+        raise ValueError(
+            f"Multiple baseline Questionnaires found for '{key}' "
+            f"(language missing or '{DEFAULT_BASELINE_LANGUAGE}')"
+        )
+
+    baseline = copy.deepcopy(baselines[0])
+    baseline.setdefault("language", DEFAULT_BASELINE_LANGUAGE)
+
+    variants = [q for q in questionnaires if q is not baselines[0]]
+    seen_languages: set[str] = set()
+    prepared: list[tuple[str, dict]] = []
+    for variant in variants:
+        language = variant.get("language")
+        if not language:
+            raise ValueError(f"Questionnaire language variant for '{key}' is missing 'language'")
+        if _is_baseline_language(language):
+            raise ValueError(f"Questionnaire language variant for '{key}' has baseline language '{language}'")
+        if language in seen_languages:
+            raise ValueError(f"Duplicate Questionnaire language '{language}' for '{key}'")
+        seen_languages.add(language)
+        prepared.append((language, variant))
+
+    for language, variant in sorted(prepared, key=lambda item: item[0]):
+        _apply_variant(baseline, variant, language, key)
+
+    return baseline
+
+
+def _apply_variant(baseline: dict, variant: dict, language: str, key: str) -> None:
+    for field in ROOT_TRANSLATABLE_FIELDS:
+        content = variant.get(field)
+        if content is not None and field in baseline:
+            _upsert_translation(baseline, field, language, content)
+
+    texts_by_link_id = _collect_text_by_link_id(variant.get("item", []))
+    applied_link_ids = _apply_item_translations(
+        baseline.get("item", []), texts_by_link_id, language, key
+    )
+
+    skipped = set(texts_by_link_id) - applied_link_ids
+    for link_id in sorted(skipped):
+        logging.warning(
+            "Skipping translation for linkId '%s' in language '%s' for Questionnaire '%s': "
+            "linkId not present in baseline",
+            link_id,
+            language,
+            key,
+        )
+
+
+def _collect_text_by_link_id(items: list[dict]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in items:
+        if "text" in item:
+            result[item["linkId"]] = item["text"]
+        result.update(_collect_text_by_link_id(item.get("item", [])))
+    return result
+
+
+def _apply_item_translations(
+    items: list[dict], texts_by_link_id: dict[str, str], language: str, key: str
+) -> set[str]:
+    applied: set[str] = set()
+    for item in items:
+        link_id = item["linkId"]
+        if link_id in texts_by_link_id:
+            if "text" not in item:
+                raise ValueError(
+                    f"Questionnaire '{key}' baseline item '{link_id}' is missing 'text'; "
+                    f"add the origin text to the baseline resource before translating to '{language}'"
+                )
+            _upsert_translation(item, "text", language, texts_by_link_id[link_id])
+            applied.add(link_id)
+        applied.update(_apply_item_translations(item.get("item", []), texts_by_link_id, language, key))
+    return applied
+
+
+def _upsert_translation(node: dict, field: str, language: str, content: str) -> None:
+    # http://hl7.org/fhir/StructureDefinition/translation always has extension: [lang, content]
+    element_key = f"_{field}"
+    element = node.setdefault(element_key, {})
+    extensions = element.setdefault("extension", [])
+
+    for extension in extensions:
+        if extension.get("url") != TRANSLATION_URL:
+            continue
+        nested = extension["extension"]
+        lang = next(e["valueCode"] for e in nested if e["url"] == "lang")
+        if lang == language:
+            content_ext = next(e for e in nested if e["url"] == "content")
+            content_ext["valueString"] = content
+            return
+
+    extensions.append(
+        {
+            "url": TRANSLATION_URL,
+            "extension": [
+                {"url": "lang", "valueCode": language},
+                {"url": "content", "valueString": content},
+            ],
+        }
+    )

--- a/fhirsnake/questionnaire_language.py
+++ b/fhirsnake/questionnaire_language.py
@@ -12,7 +12,7 @@ def merge_questionnaire_language_variants(resources_list: list[dict]) -> list[di
 
     Non-Questionnaire resources and single-questionnaire groups pass through unchanged.
     Multiple language variants are combined into one baseline resource with FHIR translation
-    extensions on item.text, title, and description.
+    extensions on item.text, item.answerOption[].valueCoding.display, title, and description.
     """
     groups: dict[str, list[dict]] = defaultdict(list)
     non_questionnaires: list[dict] = []
@@ -86,10 +86,10 @@ def _apply_variant(baseline: dict, variant: dict, language: str, key: str) -> No
         if content is not None and field in baseline:
             _upsert_translation(baseline, field, language, content)
 
-    texts_by_link_id = _collect_text_by_link_id(variant.get("item", []))
-    applied_link_ids = _apply_item_translations(baseline.get("item", []), texts_by_link_id, language, key)
+    translations_by_link_id = _collect_translations_by_link_id(variant.get("item", []), language, key)
+    applied_link_ids = _apply_item_translations(baseline.get("item", []), translations_by_link_id, language, key)
 
-    skipped = set(texts_by_link_id) - applied_link_ids
+    skipped = set(translations_by_link_id) - applied_link_ids
     for link_id in sorted(skipped):
         logging.warning(
             "Skipping translation for linkId '%s' in language '%s' for Questionnaire '%s': "
@@ -100,29 +100,103 @@ def _apply_variant(baseline: dict, variant: dict, language: str, key: str) -> No
         )
 
 
-def _collect_text_by_link_id(items: list[dict]) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _coding_key(coding: dict) -> str | None:
+    return coding.get("code")
+
+
+def _collect_translations_by_link_id(items: list[dict], language: str, key: str) -> dict[str, dict]:
+    result: dict[str, dict] = {}
     for item in items:
+        link_id = item["linkId"]
+        entry: dict = {}
         if "text" in item:
-            result[item["linkId"]] = item["text"]
-        result.update(_collect_text_by_link_id(item.get("item", [])))
+            entry["text"] = item["text"]
+
+        answer_options: dict[str, str] = {}
+        for option in item.get("answerOption", []):
+            coding = option.get("valueCoding")
+            if not coding:
+                continue
+            code = _coding_key(coding)
+            if not code:
+                logging.warning(
+                    "Skipping answerOption without code in linkId '%s' in language '%s' "
+                    "for Questionnaire '%s'",
+                    link_id,
+                    language,
+                    key,
+                )
+                continue
+            if "display" in coding:
+                answer_options[code] = coding["display"]
+
+        if answer_options:
+            entry["answerOption"] = answer_options
+
+        if entry:
+            result[link_id] = entry
+
+        result.update(_collect_translations_by_link_id(item.get("item", []), language, key))
     return result
 
 
-def _apply_item_translations(items: list[dict], texts_by_link_id: dict[str, str], language: str, key: str) -> set[str]:
+def _apply_item_translations(
+    items: list[dict],
+    translations_by_link_id: dict[str, dict],
+    language: str,
+    key: str,
+) -> set[str]:
     applied: set[str] = set()
     for item in items:
         link_id = item["linkId"]
-        if link_id in texts_by_link_id:
-            if "text" not in item:
-                raise ValueError(
-                    f"Questionnaire '{key}' baseline item '{link_id}' is missing 'text'; "
-                    f"add the origin text to the baseline resource before translating to '{language}'"
-                )
-            _upsert_translation(item, "text", language, texts_by_link_id[link_id])
+        if link_id in translations_by_link_id:
+            translations = translations_by_link_id[link_id]
+
+            if "text" in translations:
+                if "text" not in item:
+                    raise ValueError(
+                        f"Questionnaire '{key}' baseline item '{link_id}' is missing 'text'; "
+                        f"add the origin text to the baseline resource before translating to '{language}'"
+                    )
+                _upsert_translation(item, "text", language, translations["text"])
+
+            if "answerOption" in translations:
+                _apply_answer_option_translations(item, translations["answerOption"], language, key, link_id)
+
             applied.add(link_id)
-        applied.update(_apply_item_translations(item.get("item", []), texts_by_link_id, language, key))
+        applied.update(_apply_item_translations(item.get("item", []), translations_by_link_id, language, key))
     return applied
+
+
+def _apply_answer_option_translations(
+    item: dict,
+    option_displays: dict[str, str],
+    language: str,
+    key: str,
+    link_id: str,
+) -> None:
+    baseline_by_code: dict[str, dict] = {}
+    for option in item.get("answerOption", []):
+        coding = option.get("valueCoding")
+        if not coding:
+            continue
+        code = _coding_key(coding)
+        if code:
+            baseline_by_code[code] = coding
+
+    for code, display in option_displays.items():
+        coding = baseline_by_code.get(code)
+        if coding is None:
+            raise ValueError(
+                f"Questionnaire '{key}' baseline item '{link_id}' has no answerOption with code '{code}'; "
+                f"add the origin option to the baseline resource before translating to '{language}'"
+            )
+        if "display" not in coding:
+            raise ValueError(
+                f"Questionnaire '{key}' baseline item '{link_id}' answerOption '{code}' is missing 'display'; "
+                f"add the origin display to the baseline resource before translating to '{language}'"
+            )
+        _upsert_translation(coding, "display", language, display)
 
 
 def _upsert_translation(node: dict, field: str, language: str, content: str) -> None:

--- a/fhirsnake/questionnaire_language.py
+++ b/fhirsnake/questionnaire_language.py
@@ -35,6 +35,11 @@ def _group_key(resource: dict) -> str:
     return resource.get("url") or resource["id"]
 
 
+def questionnaire_group_key(resource: dict) -> str:
+    """Return the key used to group Questionnaire language variants (url, else id)."""
+    return _group_key(resource)
+
+
 def _is_baseline_language(language: str | None) -> bool:
     return language is None or language == DEFAULT_BASELINE_LANGUAGE
 
@@ -82,9 +87,7 @@ def _apply_variant(baseline: dict, variant: dict, language: str, key: str) -> No
             _upsert_translation(baseline, field, language, content)
 
     texts_by_link_id = _collect_text_by_link_id(variant.get("item", []))
-    applied_link_ids = _apply_item_translations(
-        baseline.get("item", []), texts_by_link_id, language, key
-    )
+    applied_link_ids = _apply_item_translations(baseline.get("item", []), texts_by_link_id, language, key)
 
     skipped = set(texts_by_link_id) - applied_link_ids
     for link_id in sorted(skipped):
@@ -106,9 +109,7 @@ def _collect_text_by_link_id(items: list[dict]) -> dict[str, str]:
     return result
 
 
-def _apply_item_translations(
-    items: list[dict], texts_by_link_id: dict[str, str], language: str, key: str
-) -> set[str]:
+def _apply_item_translations(items: list[dict], texts_by_link_id: dict[str, str], language: str, key: str) -> set[str]:
     applied: set[str] = set()
     for item in items:
         link_id = item["linkId"]

--- a/fhirsnake/watch.py
+++ b/fhirsnake/watch.py
@@ -8,6 +8,7 @@ from converter import (
     embed_mapping_into_questionnaire,
 )
 from files import load_resource, load_resources
+from questionnaire_language import merge_questionnaire_language_variants
 from utils import replace_urn_uuid_with_reference, substitute_env_vars
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -154,11 +155,15 @@ def start_watcher(
     external_questionnaire_fce_fhir_converter_url: str | None,
     embed_mapping: bool = False,
 ):
+    resources_list: list[dict] = []
+    for input_dir in input_dirs:
+        for by_id in load_resources(input_dir).values():
+            resources_list.extend(by_id.values())
+    resources_list = merge_questionnaire_language_variants(resources_list)
+
     all_resources: dict = {}
-    if embed_mapping:
-        for input_dir in input_dirs:
-            for resource_type, by_id in load_resources(input_dir).items():
-                all_resources.setdefault(resource_type, {}).update(by_id)
+    for resource in resources_list:
+        all_resources.setdefault(resource["resourceType"], {})[resource["id"]] = resource
 
     observer = Observer()
 

--- a/fhirsnake/watch.py
+++ b/fhirsnake/watch.py
@@ -8,7 +8,10 @@ from converter import (
     embed_mapping_into_questionnaire,
 )
 from files import load_resource, load_resources
-from questionnaire_language import merge_questionnaire_language_variants
+from questionnaire_language import (
+    merge_questionnaire_language_variants,
+    questionnaire_group_key,
+)
 from utils import replace_urn_uuid_with_reference, substitute_env_vars
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -39,6 +42,7 @@ class FileChangeHandler(FileSystemEventHandler):
         external_questionnaire_fce_fhir_converter_url: str | None,
         embed_mapping: bool = False,
         all_resources: dict | None = None,
+        raw_questionnaires: dict | None = None,
         *args,
         **kwargs,
     ) -> None:
@@ -48,6 +52,7 @@ class FileChangeHandler(FileSystemEventHandler):
         self.external_questionnaire_fce_fhir_converter_url = external_questionnaire_fce_fhir_converter_url
         self.embed_mapping = embed_mapping
         self.all_resources = all_resources if all_resources is not None else {}
+        self.raw_questionnaires = raw_questionnaires if raw_questionnaires is not None else {}
         super().__init__(*args, **kwargs)
 
     def on_modified(self, event):
@@ -81,8 +86,14 @@ class FileChangeHandler(FileSystemEventHandler):
                 self._send_resource(processed)
             return
 
+        if resource_type == "Questionnaire":
+            try:
+                resource = self._remerge_questionnaires(resource)
+            except Exception:
+                logging.exception("Unable to merge Questionnaire language variants for %s", file_path)
+                return
+
         if self.embed_mapping and resource_type == "Questionnaire":
-            self.all_resources.setdefault("Questionnaire", {})[resource_id] = resource
             resource = embed_mapping_into_questionnaire(resource, self.all_resources.get("Mapping", {}))
 
         if self.external_questionnaire_fce_fhir_converter_url and resource_type == "Questionnaire":
@@ -94,7 +105,22 @@ class FileChangeHandler(FileSystemEventHandler):
                 logging.exception("Unable to convert resource %s", file_path)
                 return
 
+        if resource_type != "Questionnaire":
+            self.all_resources.setdefault(resource_type, {})[resource_id] = resource
+
         self._send_resource(resource)
+
+    def _remerge_questionnaires(self, changed: dict) -> dict:
+        self.raw_questionnaires[changed["id"]] = changed
+        merged = merge_questionnaire_language_variants(list(self.raw_questionnaires.values()))
+        self.all_resources["Questionnaire"] = {q["id"]: q for q in merged}
+
+        group_key = questionnaire_group_key(changed)
+        for questionnaire in merged:
+            if questionnaire_group_key(questionnaire) == group_key:
+                return questionnaire
+
+        raise ValueError(f"Merged Questionnaire for group '{group_key}' was not found")
 
     def _send_resource(self, resource: dict):
         resource_type = resource["resourceType"]
@@ -155,14 +181,17 @@ def start_watcher(
     external_questionnaire_fce_fhir_converter_url: str | None,
     embed_mapping: bool = False,
 ):
+    raw_questionnaires: dict = {}
+    all_resources: dict = {}
+
     resources_list: list[dict] = []
     for input_dir in input_dirs:
-        for by_id in load_resources(input_dir).values():
+        for resource_type, by_id in load_resources(input_dir).items():
+            if resource_type == "Questionnaire":
+                raw_questionnaires.update(by_id)
             resources_list.extend(by_id.values())
-    resources_list = merge_questionnaire_language_variants(resources_list)
 
-    all_resources: dict = {}
-    for resource in resources_list:
+    for resource in merge_questionnaire_language_variants(resources_list):
         all_resources.setdefault(resource["resourceType"], {})[resource["id"]] = resource
 
     observer = Observer()
@@ -175,6 +204,7 @@ def start_watcher(
             external_questionnaire_fce_fhir_converter_url,
             embed_mapping=embed_mapping,
             all_resources=all_resources,
+            raw_questionnaires=raw_questionnaires,
         )
         observer.schedule(event_handler, input_dir, recursive=True)
     observer.start()

--- a/resources/Questionnaire/demo-questionnaire.de.yaml
+++ b/resources/Questionnaire/demo-questionnaire.de.yaml
@@ -1,0 +1,15 @@
+resourceType: Questionnaire
+id: demo-questionnaire.de
+url: demo-questionnaire
+language: de
+status: active
+title: Demo-Fragebogen
+description: Ein kurzer Demo-Fragebogen für Sprachzusammenführung
+item:
+  - type: group
+    linkId: group-1
+    text: Gruppe 1
+    item:
+      - linkId: chief-complaint
+        type: string
+        text: Hauptbeschwerde

--- a/resources/Questionnaire/demo-questionnaire.de.yaml
+++ b/resources/Questionnaire/demo-questionnaire.de.yaml
@@ -13,3 +13,13 @@ item:
       - linkId: chief-complaint
         type: string
         text: Hauptbeschwerde
+  - linkId: pain-level
+    type: choice
+    text: Schmerzintensität
+    answerOption:
+      - valueCoding:
+          code: mild
+          display: Leicht
+      - valueCoding:
+          code: severe
+          display: Schwer

--- a/resources/Questionnaire/demo-questionnaire.fr.yaml
+++ b/resources/Questionnaire/demo-questionnaire.fr.yaml
@@ -12,3 +12,13 @@ item:
   - linkId: chief-complaint
     type: string
     text: Motif de consultation
+  - linkId: pain-level
+    type: choice
+    text: Niveau de douleur
+    answerOption:
+      - valueCoding:
+          code: severe
+          display: Sévère
+      - valueCoding:
+          code: mild
+          display: Léger

--- a/resources/Questionnaire/demo-questionnaire.fr.yaml
+++ b/resources/Questionnaire/demo-questionnaire.fr.yaml
@@ -1,0 +1,14 @@
+resourceType: Questionnaire
+id: demo-questionnaire.fr
+url: demo-questionnaire
+language: fr
+status: active
+title: Questionnaire de démonstration
+description: Un court questionnaire de démonstration pour la fusion de langues
+item:
+  - type: group
+    linkId: group-1
+    text: Groupe 1
+  - linkId: chief-complaint
+    type: string
+    text: Motif de consultation

--- a/resources/Questionnaire/demo-questionnaire.yaml
+++ b/resources/Questionnaire/demo-questionnaire.yaml
@@ -13,3 +13,15 @@ item:
       - linkId: chief-complaint
         type: string
         text: Chief complaint
+  - linkId: pain-level
+    type: choice
+    text: Pain level
+    answerOption:
+      - valueCoding:
+          code: mild
+          system: http://example.org/pain-level
+          display: Mild
+      - valueCoding:
+          code: severe
+          system: http://example.org/pain-level
+          display: Severe

--- a/resources/Questionnaire/demo-questionnaire.yaml
+++ b/resources/Questionnaire/demo-questionnaire.yaml
@@ -1,0 +1,15 @@
+resourceType: Questionnaire
+id: demo-questionnaire
+url: demo-questionnaire
+language: en
+status: active
+title: Demo questionnaire
+description: A short demo questionnaire for language merging
+item:
+  - type: group
+    linkId: group-1
+    text: Group 1
+    item:
+      - linkId: chief-complaint
+        type: string
+        text: Chief complaint

--- a/tests/test_questionnaire_language.py
+++ b/tests/test_questionnaire_language.py
@@ -1,0 +1,676 @@
+import copy
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, "fhirsnake")
+
+from export import flatten_resources
+from files import load_resources
+from questionnaire_language import merge_questionnaire_language_variants
+
+RESOURCES_DIR = os.path.join(os.path.dirname(__file__), "..", "resources")
+
+BASELINE = {
+    "resourceType": "Questionnaire",
+    "id": "demo-questionnaire",
+    "url": "demo-questionnaire",
+    "language": "en",
+    "status": "active",
+    "title": "Demo questionnaire",
+    "description": "A short demo questionnaire for language merging",
+    "item": [
+        {
+            "type": "group",
+            "linkId": "group-1",
+            "text": "Group 1",
+            "item": [
+                {
+                    "linkId": "chief-complaint",
+                    "type": "string",
+                    "text": "Chief complaint",
+                }
+            ],
+        }
+    ],
+}
+
+VARIANT_DE_NESTED = {
+    "resourceType": "Questionnaire",
+    "id": "demo-questionnaire.de",
+    "url": "demo-questionnaire",
+    "language": "de",
+    "status": "active",
+    "title": "Demo-Fragebogen",
+    "description": "Ein kurzer Demo-Fragebogen für Sprachzusammenführung",
+    "item": [
+        {
+            "type": "group",
+            "linkId": "group-1",
+            "text": "Gruppe 1",
+            "item": [
+                {
+                    "linkId": "chief-complaint",
+                    "type": "string",
+                    "text": "Hauptbeschwerde",
+                }
+            ],
+        }
+    ],
+}
+
+VARIANT_FR_FLAT = {
+    "resourceType": "Questionnaire",
+    "id": "demo-questionnaire.fr",
+    "url": "demo-questionnaire",
+    "language": "fr",
+    "status": "active",
+    "title": "Questionnaire de démonstration",
+    "description": "Un court questionnaire de démonstration pour la fusion de langues",
+    "item": [
+        {
+            "type": "group",
+            "linkId": "group-1",
+            "text": "Groupe 1",
+        },
+        {
+            "linkId": "chief-complaint",
+            "type": "string",
+            "text": "Motif de consultation",
+        },
+    ],
+}
+
+MERGED_EN_DE_FR = {
+    "resourceType": "Questionnaire",
+    "id": "demo-questionnaire",
+    "url": "demo-questionnaire",
+    "language": "en",
+    "status": "active",
+    "title": "Demo questionnaire",
+    "description": "A short demo questionnaire for language merging",
+    "_title": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Demo-Fragebogen"},
+                ],
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "fr"},
+                    {"url": "content", "valueString": "Questionnaire de démonstration"},
+                ],
+            },
+        ]
+    },
+    "_description": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Ein kurzer Demo-Fragebogen für Sprachzusammenführung"},
+                ],
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "fr"},
+                    {
+                        "url": "content",
+                        "valueString": "Un court questionnaire de démonstration pour la fusion de langues",
+                    },
+                ],
+            },
+        ]
+    },
+    "item": [
+        {
+            "type": "group",
+            "linkId": "group-1",
+            "text": "Group 1",
+            "_text": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {"url": "lang", "valueCode": "de"},
+                            {"url": "content", "valueString": "Gruppe 1"},
+                        ],
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {"url": "lang", "valueCode": "fr"},
+                            {"url": "content", "valueString": "Groupe 1"},
+                        ],
+                    },
+                ]
+            },
+            "item": [
+                {
+                    "linkId": "chief-complaint",
+                    "type": "string",
+                    "text": "Chief complaint",
+                    "_text": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {"url": "lang", "valueCode": "de"},
+                                    {"url": "content", "valueString": "Hauptbeschwerde"},
+                                ],
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {"url": "lang", "valueCode": "fr"},
+                                    {"url": "content", "valueString": "Motif de consultation"},
+                                ],
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+MERGED_EN_DE = {
+    "resourceType": "Questionnaire",
+    "id": "demo-questionnaire",
+    "url": "demo-questionnaire",
+    "language": "en",
+    "status": "active",
+    "title": "Demo questionnaire",
+    "description": "A short demo questionnaire for language merging",
+    "_title": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Demo-Fragebogen"},
+                ],
+            },
+        ]
+    },
+    "_description": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Ein kurzer Demo-Fragebogen für Sprachzusammenführung"},
+                ],
+            },
+        ]
+    },
+    "item": [
+        {
+            "type": "group",
+            "linkId": "group-1",
+            "text": "Group 1",
+            "_text": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {"url": "lang", "valueCode": "de"},
+                            {"url": "content", "valueString": "Gruppe 1"},
+                        ],
+                    },
+                ]
+            },
+            "item": [
+                {
+                    "linkId": "chief-complaint",
+                    "type": "string",
+                    "text": "Chief complaint",
+                    "_text": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {"url": "lang", "valueCode": "de"},
+                                    {"url": "content", "valueString": "Hauptbeschwerde"},
+                                ],
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+
+class TestMergeQuestionnaireLanguageVariants:
+    def test_single_questionnaire_passes_through_unchanged(self):
+        questionnaire = {
+            "resourceType": "Questionnaire",
+            "id": "alone",
+            "url": "alone",
+            "status": "active",
+            "title": "Alone",
+            "item": [{"linkId": "q1", "type": "string", "text": "Question"}],
+        }
+
+        result = merge_questionnaire_language_variants([questionnaire])
+
+        assert result == [questionnaire]
+
+    def test_single_questionnaire_with_non_en_language_passes_through(self):
+        questionnaire = {
+            "resourceType": "Questionnaire",
+            "id": "de-only",
+            "url": "de-only",
+            "language": "de",
+            "status": "active",
+            "title": "Nur Deutsch",
+            "item": [{"linkId": "q1", "type": "string", "text": "Frage"}],
+        }
+
+        result = merge_questionnaire_language_variants([questionnaire])
+
+        assert result == [questionnaire]
+
+    def test_single_questionnaire_without_language_passes_through(self):
+        questionnaire = {
+            "resourceType": "Questionnaire",
+            "id": "no-lang",
+            "status": "active",
+            "title": "No language",
+            "item": [{"linkId": "q1", "type": "string", "text": "Question"}],
+        }
+
+        result = merge_questionnaire_language_variants([questionnaire])
+
+        assert result == [questionnaire]
+
+    def test_two_variants_merge_nested_de(self):
+        result = merge_questionnaire_language_variants([copy.deepcopy(BASELINE), copy.deepcopy(VARIANT_DE_NESTED)])
+
+        assert result == [MERGED_EN_DE]
+
+    def test_flat_and_nested_variants_produce_same_merged_result(self):
+        variant_de_flat = {
+            "resourceType": "Questionnaire",
+            "id": "demo-questionnaire.de",
+            "url": "demo-questionnaire",
+            "language": "de",
+            "status": "active",
+            "title": "Demo-Fragebogen",
+            "description": "Ein kurzer Demo-Fragebogen für Sprachzusammenführung",
+            "item": [
+                {"type": "group", "linkId": "group-1", "text": "Gruppe 1"},
+                {"linkId": "chief-complaint", "type": "string", "text": "Hauptbeschwerde"},
+            ],
+        }
+
+        nested_result = merge_questionnaire_language_variants(
+            [copy.deepcopy(BASELINE), copy.deepcopy(VARIANT_DE_NESTED)]
+        )
+        flat_result = merge_questionnaire_language_variants([copy.deepcopy(BASELINE), variant_de_flat])
+
+        assert nested_result == [MERGED_EN_DE]
+        assert flat_result == [MERGED_EN_DE]
+        assert nested_result == flat_result
+
+    def test_three_variants_merge_en_de_fr(self):
+        result = merge_questionnaire_language_variants(
+            [copy.deepcopy(BASELINE), copy.deepcopy(VARIANT_DE_NESTED), copy.deepcopy(VARIANT_FR_FLAT)]
+        )
+
+        assert result == [MERGED_EN_DE_FR]
+
+    def test_grouping_falls_back_to_id_when_url_missing(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "shared-id",
+            "language": "en",
+            "status": "active",
+            "title": "Shared",
+            "item": [{"linkId": "q1", "type": "string", "text": "Hello"}],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "shared-id",
+            "language": "de",
+            "status": "active",
+            "title": "Geteilt",
+            "item": [{"linkId": "q1", "type": "string", "text": "Hallo"}],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        expected = {
+            "resourceType": "Questionnaire",
+            "id": "shared-id",
+            "language": "en",
+            "status": "active",
+            "title": "Shared",
+            "_title": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {"url": "lang", "valueCode": "de"},
+                            {"url": "content", "valueString": "Geteilt"},
+                        ],
+                    },
+                ]
+            },
+            "item": [
+                {
+                    "linkId": "q1",
+                    "type": "string",
+                    "text": "Hello",
+                    "_text": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {"url": "lang", "valueCode": "de"},
+                                    {"url": "content", "valueString": "Hallo"},
+                                ],
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+        assert result == [expected]
+
+    def test_defaults_missing_baseline_language_to_en(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "status": "active",
+            "title": "Demo",
+            "item": [{"linkId": "q1", "type": "string", "text": "Hello"}],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "title": "Demo DE",
+            "item": [{"linkId": "q1", "type": "string", "text": "Hallo"}],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        expected = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "title": "Demo",
+            "_title": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {"url": "lang", "valueCode": "de"},
+                            {"url": "content", "valueString": "Demo DE"},
+                        ],
+                    },
+                ]
+            },
+            "item": [
+                {
+                    "linkId": "q1",
+                    "type": "string",
+                    "text": "Hello",
+                    "_text": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {"url": "lang", "valueCode": "de"},
+                                    {"url": "content", "valueString": "Hallo"},
+                                ],
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+        assert result == [expected]
+
+    def test_raises_when_no_baseline(self):
+        de = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [],
+        }
+        fr = {
+            "resourceType": "Questionnaire",
+            "id": "demo.fr",
+            "url": "demo",
+            "language": "fr",
+            "status": "active",
+            "item": [],
+        }
+
+        with pytest.raises(ValueError, match="No baseline Questionnaire"):
+            merge_questionnaire_language_variants([de, fr])
+
+    def test_raises_when_multiple_baselines(self):
+        first = {
+            "resourceType": "Questionnaire",
+            "id": "demo-1",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [],
+        }
+        second = {
+            "resourceType": "Questionnaire",
+            "id": "demo-2",
+            "url": "demo",
+            "status": "active",
+            "item": [],
+        }
+
+        with pytest.raises(ValueError, match="Multiple baseline Questionnaires"):
+            merge_questionnaire_language_variants([first, second])
+
+    def test_raises_when_variant_has_empty_language(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo-variant",
+            "url": "demo",
+            "language": "",
+            "status": "active",
+            "item": [],
+        }
+
+        with pytest.raises(ValueError, match="missing 'language'"):
+            merge_questionnaire_language_variants([baseline, variant])
+
+    def test_raises_when_duplicate_variant_language(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [],
+        }
+        first_de = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de-1",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [],
+        }
+        second_de = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de-2",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [],
+        }
+
+        with pytest.raises(ValueError, match="Duplicate Questionnaire language"):
+            merge_questionnaire_language_variants([baseline, first_de, second_de])
+
+    def test_skips_variant_link_id_missing_from_baseline(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "title": "Demo",
+            "item": [{"linkId": "known", "type": "string", "text": "Known"}],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.fr",
+            "url": "demo",
+            "language": "fr",
+            "status": "active",
+            "title": "Démo",
+            "item": [
+                {"linkId": "known", "type": "string", "text": "Connu"},
+                {"linkId": "extra-only-in-fr", "type": "string", "text": "Extra"},
+            ],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        expected = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "title": "Demo",
+            "_title": {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                        "extension": [
+                            {"url": "lang", "valueCode": "fr"},
+                            {"url": "content", "valueString": "Démo"},
+                        ],
+                    },
+                ]
+            },
+            "item": [
+                {
+                    "linkId": "known",
+                    "type": "string",
+                    "text": "Known",
+                    "_text": {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                                "extension": [
+                                    {"url": "lang", "valueCode": "fr"},
+                                    {"url": "content", "valueString": "Connu"},
+                                ],
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+        assert result == [expected]
+
+    def test_raises_when_baseline_item_missing_text(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [{"linkId": "q1", "type": "string"}],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.fr",
+            "url": "demo",
+            "language": "fr",
+            "status": "active",
+            "item": [{"linkId": "q1", "type": "string", "text": "Question"}],
+        }
+
+        with pytest.raises(ValueError, match="baseline item 'q1' is missing 'text'"):
+            merge_questionnaire_language_variants([baseline, variant])
+
+    def test_preserves_non_questionnaire_and_unrelated_questionnaires(self):
+        patient = {"resourceType": "Patient", "id": "p1", "name": [{"family": "Doe"}]}
+        other = {
+            "resourceType": "Questionnaire",
+            "id": "other",
+            "url": "other",
+            "status": "active",
+            "title": "Other",
+            "item": [{"linkId": "o1", "type": "string", "text": "Other Q"}],
+        }
+
+        result = merge_questionnaire_language_variants(
+            [
+                patient,
+                copy.deepcopy(BASELINE),
+                other,
+                copy.deepcopy(VARIANT_DE_NESTED),
+                copy.deepcopy(VARIANT_FR_FLAT),
+            ]
+        )
+
+        assert len(result) == 3
+        assert patient in result
+        assert other in result
+        assert MERGED_EN_DE_FR in result
+
+    def test_does_not_mutate_input_resources(self):
+        baseline = copy.deepcopy(BASELINE)
+        variant_de = copy.deepcopy(VARIANT_DE_NESTED)
+        variant_fr = copy.deepcopy(VARIANT_FR_FLAT)
+        original_baseline = copy.deepcopy(baseline)
+        original_de = copy.deepcopy(variant_de)
+        original_fr = copy.deepcopy(variant_fr)
+
+        merge_questionnaire_language_variants([baseline, variant_de, variant_fr])
+
+        assert baseline == original_baseline
+        assert variant_de == original_de
+        assert variant_fr == original_fr
+
+    def test_loads_and_merges_demo_resources_from_resources_dir(self):
+        loaded = flatten_resources(load_resources(RESOURCES_DIR))
+        demo_resources = [
+            resource
+            for resource in loaded
+            if resource.get("resourceType") == "Questionnaire" and resource.get("url") == "demo-questionnaire"
+        ]
+
+        result = merge_questionnaire_language_variants(demo_resources)
+
+        assert result == [MERGED_EN_DE_FR]

--- a/tests/test_questionnaire_language.py
+++ b/tests/test_questionnaire_language.py
@@ -12,6 +12,179 @@ from questionnaire_language import merge_questionnaire_language_variants
 
 RESOURCES_DIR = os.path.join(os.path.dirname(__file__), "..", "resources")
 
+PAIN_LEVEL_BASELINE = {
+    "linkId": "pain-level",
+    "type": "choice",
+    "text": "Pain level",
+    "answerOption": [
+        {
+            "valueCoding": {
+                "code": "mild",
+                "system": "http://example.org/pain-level",
+                "display": "Mild",
+            }
+        },
+        {
+            "valueCoding": {
+                "code": "severe",
+                "system": "http://example.org/pain-level",
+                "display": "Severe",
+            }
+        },
+    ],
+}
+
+PAIN_LEVEL_VARIANT_DE = {
+    "linkId": "pain-level",
+    "type": "choice",
+    "text": "Schmerzintensität",
+    "answerOption": [
+        {"valueCoding": {"code": "mild", "display": "Leicht"}},
+        {"valueCoding": {"code": "severe", "display": "Schwer"}},
+    ],
+}
+
+PAIN_LEVEL_VARIANT_FR = {
+    "linkId": "pain-level",
+    "type": "choice",
+    "text": "Niveau de douleur",
+    "answerOption": [
+        {"valueCoding": {"code": "severe", "display": "Sévère"}},
+        {"valueCoding": {"code": "mild", "display": "Léger"}},
+    ],
+}
+
+PAIN_LEVEL_MERGED_EN_DE = {
+    "linkId": "pain-level",
+    "type": "choice",
+    "text": "Pain level",
+    "_text": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Schmerzintensität"},
+                ],
+            },
+        ]
+    },
+    "answerOption": [
+        {
+            "valueCoding": {
+                "code": "mild",
+                "system": "http://example.org/pain-level",
+                "display": "Mild",
+                "_display": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                            "extension": [
+                                {"url": "lang", "valueCode": "de"},
+                                {"url": "content", "valueString": "Leicht"},
+                            ],
+                        },
+                    ]
+                },
+            }
+        },
+        {
+            "valueCoding": {
+                "code": "severe",
+                "system": "http://example.org/pain-level",
+                "display": "Severe",
+                "_display": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                            "extension": [
+                                {"url": "lang", "valueCode": "de"},
+                                {"url": "content", "valueString": "Schwer"},
+                            ],
+                        },
+                    ]
+                },
+            }
+        },
+    ],
+}
+
+PAIN_LEVEL_MERGED_EN_DE_FR = {
+    "linkId": "pain-level",
+    "type": "choice",
+    "text": "Pain level",
+    "_text": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Schmerzintensität"},
+                ],
+            },
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "fr"},
+                    {"url": "content", "valueString": "Niveau de douleur"},
+                ],
+            },
+        ]
+    },
+    "answerOption": [
+        {
+            "valueCoding": {
+                "code": "mild",
+                "system": "http://example.org/pain-level",
+                "display": "Mild",
+                "_display": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                            "extension": [
+                                {"url": "lang", "valueCode": "de"},
+                                {"url": "content", "valueString": "Leicht"},
+                            ],
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                            "extension": [
+                                {"url": "lang", "valueCode": "fr"},
+                                {"url": "content", "valueString": "Léger"},
+                            ],
+                        },
+                    ]
+                },
+            }
+        },
+        {
+            "valueCoding": {
+                "code": "severe",
+                "system": "http://example.org/pain-level",
+                "display": "Severe",
+                "_display": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                            "extension": [
+                                {"url": "lang", "valueCode": "de"},
+                                {"url": "content", "valueString": "Schwer"},
+                            ],
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                            "extension": [
+                                {"url": "lang", "valueCode": "fr"},
+                                {"url": "content", "valueString": "Sévère"},
+                            ],
+                        },
+                    ]
+                },
+            }
+        },
+    ],
+}
+
 BASELINE = {
     "resourceType": "Questionnaire",
     "id": "demo-questionnaire",
@@ -32,7 +205,8 @@ BASELINE = {
                     "text": "Chief complaint",
                 }
             ],
-        }
+        },
+        copy.deepcopy(PAIN_LEVEL_BASELINE),
     ],
 }
 
@@ -56,7 +230,8 @@ VARIANT_DE_NESTED = {
                     "text": "Hauptbeschwerde",
                 }
             ],
-        }
+        },
+        copy.deepcopy(PAIN_LEVEL_VARIANT_DE),
     ],
 }
 
@@ -79,6 +254,7 @@ VARIANT_FR_FLAT = {
             "type": "string",
             "text": "Motif de consultation",
         },
+        copy.deepcopy(PAIN_LEVEL_VARIANT_FR),
     ],
 }
 
@@ -177,7 +353,8 @@ MERGED_EN_DE_FR = {
                     },
                 }
             ],
-        }
+        },
+        copy.deepcopy(PAIN_LEVEL_MERGED_EN_DE_FR),
     ],
 }
 
@@ -245,7 +422,8 @@ MERGED_EN_DE = {
                     },
                 }
             ],
-        }
+        },
+        copy.deepcopy(PAIN_LEVEL_MERGED_EN_DE),
     ],
 }
 
@@ -310,6 +488,7 @@ class TestMergeQuestionnaireLanguageVariants:
             "item": [
                 {"type": "group", "linkId": "group-1", "text": "Gruppe 1"},
                 {"linkId": "chief-complaint", "type": "string", "text": "Hauptbeschwerde"},
+                copy.deepcopy(PAIN_LEVEL_VARIANT_DE),
             ],
         }
 
@@ -622,6 +801,370 @@ class TestMergeQuestionnaireLanguageVariants:
 
         with pytest.raises(ValueError, match="baseline item 'q1' is missing 'text'"):
             merge_questionnaire_language_variants([baseline, variant])
+
+    def test_raises_when_variant_answer_option_code_missing_from_baseline(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Mild"}},
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Leicht"}},
+                        {"valueCoding": {"code": "unknown", "display": "Unbekannt"}},
+                    ],
+                }
+            ],
+        }
+
+        with pytest.raises(ValueError, match="has no answerOption with code 'unknown'"):
+            merge_questionnaire_language_variants([baseline, variant])
+
+    def test_raises_when_baseline_answer_option_missing_display(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild"}},
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Leicht"}},
+                    ],
+                }
+            ],
+        }
+
+        with pytest.raises(ValueError, match="answerOption 'mild' is missing 'display'"):
+            merge_questionnaire_language_variants([baseline, variant])
+
+    def test_skips_variant_answer_option_without_code(self, caplog):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Mild"}},
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Leicht"}},
+                        {"valueCoding": {"display": "Ohne Code"}},
+                    ],
+                }
+            ],
+        }
+
+        with caplog.at_level("WARNING"):
+            result = merge_questionnaire_language_variants([baseline, variant])
+
+        assert (
+            "Skipping answerOption without code in linkId 'pain-level' "
+            "in language 'de' for Questionnaire 'demo'"
+        ) in caplog.text
+        assert result[0]["item"][0]["answerOption"][0]["valueCoding"]["_display"]["extension"] == [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Leicht"},
+                ],
+            },
+        ]
+
+    def test_skips_baseline_answer_option_without_code(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {"valueCoding": {"display": "No code"}},
+                        {"valueCoding": {"code": "mild", "display": "Mild"}},
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Leicht"}},
+                    ],
+                }
+            ],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        assert result[0]["item"][0]["answerOption"][0] == {"valueCoding": {"display": "No code"}}
+        assert result[0]["item"][0]["answerOption"][1]["valueCoding"]["_display"]["extension"] == [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Leicht"},
+                ],
+            },
+        ]
+
+    def test_skips_answer_option_without_value_coding(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {"valueString": "free text"},
+                        {"valueCoding": {"code": "mild", "display": "Mild"}},
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {"valueString": "freier Text"},
+                        {"valueCoding": {"code": "mild", "display": "Leicht"}},
+                    ],
+                }
+            ],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        assert result[0]["item"][0]["answerOption"][0] == {"valueString": "free text"}
+        assert result[0]["item"][0]["answerOption"][1]["valueCoding"]["_display"]["extension"] == [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Leicht"},
+                ],
+            },
+        ]
+
+    def test_duplicate_answer_option_codes_use_last_display(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "mild",
+                                "system": "http://example.org/a",
+                                "display": "Mild A",
+                            }
+                        },
+                        {
+                            "valueCoding": {
+                                "code": "mild",
+                                "system": "http://example.org/b",
+                                "display": "Mild B",
+                            }
+                        },
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {"valueCoding": {"code": "mild", "display": "Leicht zuerst"}},
+                        {"valueCoding": {"code": "mild", "display": "Leicht zuletzt"}},
+                    ],
+                }
+            ],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        options = result[0]["item"][0]["answerOption"]
+        assert options[0]["valueCoding"] == {
+            "code": "mild",
+            "system": "http://example.org/a",
+            "display": "Mild A",
+        }
+        assert options[1]["valueCoding"]["_display"]["extension"] == [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Leicht zuletzt"},
+                ],
+            },
+        ]
+
+    def test_matches_answer_option_by_code_ignoring_system(self):
+        baseline = {
+            "resourceType": "Questionnaire",
+            "id": "demo",
+            "url": "demo",
+            "language": "en",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Pain level",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "mild",
+                                "system": "http://example.org/pain-level",
+                                "display": "Mild",
+                            }
+                        },
+                    ],
+                }
+            ],
+        }
+        variant = {
+            "resourceType": "Questionnaire",
+            "id": "demo.de",
+            "url": "demo",
+            "language": "de",
+            "status": "active",
+            "item": [
+                {
+                    "linkId": "pain-level",
+                    "type": "choice",
+                    "text": "Schmerzintensität",
+                    "answerOption": [
+                        {
+                            "valueCoding": {
+                                "code": "mild",
+                                "system": "http://example.org/other-system",
+                                "display": "Leicht",
+                            }
+                        },
+                    ],
+                }
+            ],
+        }
+
+        result = merge_questionnaire_language_variants([baseline, variant])
+
+        coding = result[0]["item"][0]["answerOption"][0]["valueCoding"]
+        assert coding["system"] == "http://example.org/pain-level"
+        assert coding["_display"]["extension"] == [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/translation",
+                "extension": [
+                    {"url": "lang", "valueCode": "de"},
+                    {"url": "content", "valueString": "Leicht"},
+                ],
+            },
+        ]
 
     def test_preserves_non_questionnaire_and_unrelated_questionnaires(self):
         patient = {"resourceType": "Patient", "id": "p1", "name": [{"family": "Doe"}]}


### PR DESCRIPTION
- Merge Questionnaires that share the same url (fallback id) and differ by language into one baseline resource with FHIR _text / _title / _description translation extensions
- Wired into export and watch startup; supports flat and nested language files; baseline linkIds are authoritative
- Adds demo resources, tests, and README docs

Closes #14 